### PR TITLE
Add API URL env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Keep your API Key a secret!
 API_KEY=
+
+# Base URL for TheBrain API
+BRAIN_API_URL=https://api.bra.in

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is an example project that demonstrates how to make a call to TheBrain's AP
    ```bash
    $ cp .env.example .env.local
    ```
-6. Add your [API key](https://app.thebrain.com/apiKeys) to the newly created `.env.local` file
+6. Add your [API key](https://app.thebrain.com/apiKeys) to the newly created `.env.local` file. You can also override the default API endpoint by setting `BRAIN_API_URL`.
 
 7. Run the app
 
@@ -35,4 +35,5 @@ This is an example project that demonstrates how to make a call to TheBrain's AP
 You should now be able to access the app at [http://localhost:3000](http://localhost:3000).
 
 ## Contributing
+
 We welcome contributions! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on workflow, branch naming and commit format. Issue and pull request templates are available in the [`.github`](.github) directory.

--- a/src/pages/api/createThought.js
+++ b/src/pages/api/createThought.js
@@ -1,6 +1,6 @@
 export default async (req, res) => {
-
-  const { name, kind, label, typeId, sourceThoughtId, relation, acType } = req.body;
+  const { name, kind, label, typeId, sourceThoughtId, relation, acType } =
+    req.body;
   const { brainId } = req.query;
 
   const apiKey = process.env.API_KEY;
@@ -11,10 +11,11 @@ export default async (req, res) => {
   }
 
   try {
-    const response = await fetch(`https://api.bra.in/thoughts/${brainId}`, {
+    const apiUrl = process.env.BRAIN_API_URL || 'https://api.bra.in';
+    const response = await fetch(`${apiUrl}/thoughts/${brainId}`, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
+        Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -24,7 +25,7 @@ export default async (req, res) => {
         typeId,
         sourceThoughtId,
         relation,
-        acType
+        acType,
       }),
     });
 
@@ -36,6 +37,8 @@ export default async (req, res) => {
     res.status(200).json(data);
   } catch (error) {
     console.error('Error: ', error.message);
-    res.status(500).json({ error: 'An error occurred while creating the thought.' });
+    res
+      .status(500)
+      .json({ error: 'An error occurred while creating the thought.' });
   }
 };


### PR DESCRIPTION
## Summary
- support configurable API URL via `BRAIN_API_URL`
- use the variable in the createThought API route
- document the variable in README

## Testing
- `npm run lint`
- `npx prettier README.md src/pages/api/createThought.js --check`

------
https://chatgpt.com/codex/tasks/task_b_6854fbe4c5f4832597416c9e466ca782