### PR TITLE
Validate brain ID and restrict createThought API to POST

### DIFF
--- a/src/pages/api/createThought.js
+++ b/src/pages/api/createThought.js
@@ -1,7 +1,17 @@
 export default async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
 
   const { name, kind, label, typeId, sourceThoughtId, relation, acType } = req.body;
   const { brainId } = req.query;
+  const guidPattern = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
+
+  if (!brainId || !guidPattern.test(brainId)) {
+    res.status(400).json({ error: 'Invalid brainId format.' });
+    return;
+  }
 
   const apiKey = process.env.API_KEY;
 


### PR DESCRIPTION
## Summary
- reject non-POST requests to the `createThought` API
- ensure `brainId` query parameter matches GUID format before calling external API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68b51d320cac8325b5a75c60eb49eb72