### PR TITLE
fix: add missing semicolon to global CSS

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -40,6 +40,6 @@ code {
   padding: 0 0.25rem 0 0.25rem;
   background: #313a47;
   border-radius:0.25rem;
-  border: 1px solid #ffffff0f
+  border: 1px solid #ffffff0f;
 
 }


### PR DESCRIPTION
## Summary
- add missing semicolon to `code` block border rule in global styles

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_68b521bdfdf0832589aa4add4f7bb0ff