### PR TITLE
chore: clean up index page imports

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,11 +1,5 @@
 import React, { useState } from 'react';
 import Head from 'next/head';
-import Image from 'next/image'
-;
-import { Inter } from 'next/font/google'
-;
-
-const inter = Inter({ subsets: ['latin'] })
 
 export default function Home() {
   const [brainId, setBrainId] = useState('');


### PR DESCRIPTION
## Summary
- remove unused `Image` and `Inter` imports
- delete unused `inter` constant and stray semicolon lines

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_68b52f70dda08325b9fa14ac9b2ff73f