### PR TITLE
Add server-side validation for thought creation

### DIFF
--- a/src/pages/api/createThought.js
+++ b/src/pages/api/createThought.js
@@ -20,6 +20,42 @@ export default async (req, res) => {
     return;
   }
 
+  // Validate request body fields
+  if (typeof name !== 'string' || name.trim() === '') {
+    res.status(400).json({ error: 'Name is required and must be a non-empty string.' });
+    return;
+  }
+
+  if (!Number.isInteger(kind)) {
+    res.status(400).json({ error: 'Kind is required and must be an integer.' });
+    return;
+  }
+
+  if (!sourceThoughtId || !guidPattern.test(sourceThoughtId)) {
+    res.status(400).json({ error: 'Invalid sourceThoughtId format.' });
+    return;
+  }
+
+  if (!typeId || !guidPattern.test(typeId)) {
+    res.status(400).json({ error: 'Invalid typeId format.' });
+    return;
+  }
+
+  if (!Number.isInteger(relation)) {
+    res.status(400).json({ error: 'Relation is required and must be an integer.' });
+    return;
+  }
+
+  if (!Number.isInteger(acType)) {
+    res.status(400).json({ error: 'acType is required and must be an integer.' });
+    return;
+  }
+
+  if (label !== undefined && typeof label !== 'string') {
+    res.status(400).json({ error: 'Label must be a string if provided.' });
+    return;
+  }
+
   try {
     const response = await fetch(`https://api.bra.in/thoughts/${brainId}`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- validate createThought request body fields before calling external API
- return 400 errors with descriptive messages when input is missing or invalid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68b621fd811483259ab650d2d4f212ec