### PR TITLE
Encode brain ID in create thought request

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -45,7 +45,7 @@ export default function Home() {
     };
 
     try {
-      const response = await fetch(`/api/createThought?brainId=${brainId}`, {
+      const response = await fetch(`/api/createThought?brainId=${encodeURIComponent(brainId)}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- URL-encode brain ID before calling `/api/createThought`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68b6255073c083259c31646fa801cad0