### PR TITLE
feat: add csrf token validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Keep your API Key a secret!
 API_KEY=
+CSRF_TOKEN=
+NEXT_PUBLIC_CSRF_TOKEN=

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is an example project that demonstrates how to make a call to TheBrain's AP
    ```bash
    $ cp .env.example .env.local
    ```
-6. Add your [API key](https://app.thebrain.com/apiKeys) to the newly created `.env.local` file
+6. Add your [API key](https://app.thebrain.com/apiKeys) and matching `CSRF_TOKEN`/`NEXT_PUBLIC_CSRF_TOKEN` values to the newly created `.env.local` file
 
 7. Run the app
 

--- a/src/pages/api/createThought.js
+++ b/src/pages/api/createThought.js
@@ -4,6 +4,18 @@ export default async (req, res) => {
     return;
   }
 
+  const serverToken = process.env.CSRF_TOKEN;
+  if (!serverToken) {
+    res.status(500).json({ error: 'CSRF token not configured.' });
+    return;
+  }
+
+  const csrfToken = req.headers['x-csrf-token'];
+  if (!csrfToken || csrfToken !== serverToken) {
+    res.status(403).json({ error: 'Invalid or missing CSRF token.' });
+    return;
+  }
+
   const { name, kind, label, typeId, sourceThoughtId, relation, acType } = req.body;
   const { brainId } = req.query;
   const guidPattern = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,6 +8,7 @@ export default function Home() {
   const [newThoughtLabel, setNewThoughtLabel] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const csrfToken = process.env.NEXT_PUBLIC_CSRF_TOKEN;
 
   const isGuid = (value) => {
     const guidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
@@ -49,6 +50,7 @@ export default function Home() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'x-csrf-token': csrfToken,
         },
         body: JSON.stringify(body),
       });


### PR DESCRIPTION
## Summary
- add server-side CSRF token check for createThought API route
- send CSRF token in client requests
- document CSRF token configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68b6277cefa8832586dd73fedb9ca386