### PR TITLE
Handle missing API key as server error

### DIFF
--- a/src/pages/api/createThought.js
+++ b/src/pages/api/createThought.js
@@ -28,7 +28,8 @@ export default async (req, res) => {
   const apiKey = process.env.API_KEY;
 
   if (!apiKey) {
-    res.status(401).json({ error: 'API Key missing or invalid.' });
+    console.error('API key not configured. Set API_KEY environment variable.');
+    res.status(500).json({ error: 'Server configuration error' });
     return;
   }
 


### PR DESCRIPTION
## Summary
- return 500 error with generic message when API_KEY is not configured
- log missing API key server-side

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68b62ce9b1108325832f8aebfdc04dfc