### PR TITLE
Centralize GUID validation logic

### DIFF
--- a/src/pages/api/createThought.js
+++ b/src/pages/api/createThought.js
@@ -1,3 +1,5 @@
+import isGuid from '../../utils/isGuid';
+
 export default async (req, res) => {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method Not Allowed' });
@@ -18,9 +20,8 @@ export default async (req, res) => {
 
   const { name, kind, label, typeId, sourceThoughtId, relation, acType } = req.body;
   const { brainId } = req.query;
-  const guidPattern = /^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/;
 
-  if (!brainId || !guidPattern.test(brainId)) {
+  if (!brainId || !isGuid(brainId)) {
     res.status(400).json({ error: 'Invalid brainId format.' });
     return;
   }
@@ -44,12 +45,12 @@ export default async (req, res) => {
     return;
   }
 
-  if (!sourceThoughtId || !guidPattern.test(sourceThoughtId)) {
+  if (!sourceThoughtId || !isGuid(sourceThoughtId)) {
     res.status(400).json({ error: 'Invalid sourceThoughtId format.' });
     return;
   }
 
-  if (!typeId || !guidPattern.test(typeId)) {
+  if (!typeId || !isGuid(typeId)) {
     res.status(400).json({ error: 'Invalid typeId format.' });
     return;
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Head from 'next/head';
+import isGuid from '../utils/isGuid';
 
 export default function Home() {
   const [brainId, setBrainId] = useState('');
@@ -9,11 +10,6 @@ export default function Home() {
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const csrfToken = process.env.NEXT_PUBLIC_CSRF_TOKEN;
-
-  const isGuid = (value) => {
-    const guidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-    return guidPattern.test(value);
-  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/src/utils/isGuid.js
+++ b/src/utils/isGuid.js
@@ -1,0 +1,5 @@
+export default function isGuid(value) {
+  const guidPattern = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+  return guidPattern.test(value);
+}
+


### PR DESCRIPTION
## Summary
- add shared `isGuid` utility for GUID regex validation
- use `isGuid` in index and createThought to validate IDs consistently

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68b631ee0050832583d16e89f2238eb9