### PR TITLE
Handle API error responses before reading new thought id

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -85,18 +85,19 @@ export default function Home() {
         setErrorMessage(`Unexpected response format: ${text}`);
         return;
       }
+
+      if (!response.ok) {
+        setErrorMessage(data?.error || response.statusText);
+        return;
+      }
+
       if (!data || typeof data.id === 'undefined') {
         setErrorMessage(`Missing id in server response: ${JSON.stringify(data)}`);
         return;
       }
 
       const newThoughtId = data.id;
-
-      if (response.ok) {
-        setSuccessMessage(`Success! New Thought ID: ${newThoughtId}`);
-      } else {
-        setErrorMessage(data.error || 'An error occurred while creating the thought.');
-      }
+      setSuccessMessage(`Success! New Thought ID: ${newThoughtId}`);
     } catch (error) {
       setErrorMessage('Error during fetch operation: ' + error.message);
     }


### PR DESCRIPTION
## Summary
- Safely parse API response JSON
- Check `response.ok` before using the returned `id`
- Surface server errors via `data.error` or status text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68b644e5e2508325997fdd28f9c7a79f