### PR TITLE
feat: validate csrf token before request

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -60,12 +60,17 @@ export default function Home() {
       acType: 0
     };
 
+    if (!csrfToken) {
+      setErrorMessage('Missing CSRF token');
+      return;
+    }
+
     try {
       const response = await fetch(`/api/createThought?brainId=${encodeURIComponent(brainId)}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-csrf-token': csrfToken,
+          ...(csrfToken ? { 'x-csrf-token': csrfToken } : {}),
         },
         body: JSON.stringify(body),
       });


### PR DESCRIPTION
## Summary
- verify CSRF token exists before creating a thought
- only send `x-csrf-token` header when a token is present

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68b647446b588325996ce4024612bea3