### PR TITLE
Implement session-based CSRF token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,2 @@
 # Keep your API Key a secret!
 API_KEY=
-CSRF_TOKEN=
-NEXT_PUBLIC_CSRF_TOKEN=

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is an example project that demonstrates how to make a call to TheBrain's AP
    ```bash
    $ cp .env.example .env.local
    ```
-6. Add your [API key](https://app.thebrain.com/apiKeys) and matching `CSRF_TOKEN`/`NEXT_PUBLIC_CSRF_TOKEN` values to the newly created `.env.local` file
+6. Add your [API key](https://app.thebrain.com/apiKeys) to the newly created `.env.local` file
 
 7. Run the app
 

--- a/src/pages/api/createThought.js
+++ b/src/pages/api/createThought.js
@@ -18,14 +18,9 @@ export default async (req, res) => {
     return;
   }
 
-  const serverToken = process.env.CSRF_TOKEN;
-  if (!serverToken) {
-    res.status(500).json({ error: 'CSRF token not configured.' });
-    return;
-  }
-
+  const sessionToken = req.cookies?.csrfToken;
   const csrfToken = req.headers['x-csrf-token'];
-  if (!csrfToken || csrfToken !== serverToken) {
+  if (!csrfToken || csrfToken !== sessionToken) {
     res.status(403).json({ error: 'Invalid or missing CSRF token.' });
     return;
   }

--- a/src/pages/api/csrf.js
+++ b/src/pages/api/csrf.js
@@ -1,0 +1,11 @@
+import { randomBytes } from 'crypto';
+
+export default function handler(req, res) {
+  let token = req.cookies?.csrfToken;
+  if (!token) {
+    token = randomBytes(32).toString('hex');
+    const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+    res.setHeader('Set-Cookie', `csrfToken=${token}; Path=/; HttpOnly; SameSite=Strict${secure}`);
+  }
+  res.status(200).json({ token });
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import isGuid from '../utils/isGuid';
 
@@ -18,7 +18,20 @@ export default function Home() {
   const [newThoughtLabel, setNewThoughtLabel] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-  const csrfToken = process.env.NEXT_PUBLIC_CSRF_TOKEN;
+  const [csrfToken, setCsrfToken] = useState('');
+
+  useEffect(() => {
+    const fetchToken = async () => {
+      try {
+        const res = await fetch('/api/csrf');
+        const data = await res.json();
+        setCsrfToken(data.token);
+      } catch (err) {
+        setErrorMessage('Failed to fetch CSRF token: ' + err.message);
+      }
+    };
+    fetchToken();
+  }, []);
 
   /**
    * Handle submission of the create thought form.


### PR DESCRIPTION
## Summary
- issue and validate CSRF tokens per-session using new `/api/csrf` endpoint and cookies
- fetch CSRF token on page load and send with requests instead of env vars
- remove CSRF-related env vars and update docs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompt to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_b_68b64e56e97c832594e5bd46d9cd76bf