### PR TITLE
Normalize CSRF token header in createThought API

### DIFF
--- a/src/pages/api/createThought.js
+++ b/src/pages/api/createThought.js
@@ -19,7 +19,9 @@ export default async (req, res) => {
   }
 
   const sessionToken = req.cookies?.csrfToken;
-  const csrfToken = req.headers['x-csrf-token'];
+  const csrfToken = Array.isArray(req.headers['x-csrf-token'])
+    ? req.headers['x-csrf-token'][0]
+    : req.headers['x-csrf-token'];
   if (!csrfToken || csrfToken !== sessionToken) {
     res.status(403).json({ error: 'Invalid or missing CSRF token.' });
     return;


### PR DESCRIPTION
## Summary
- ensure `x-csrf-token` header is normalized to a single string before validation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: required interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_68b6519a6ed0832588630906666660c4